### PR TITLE
Bugfix: add missing parentheses around options in postgresqlViewOptions

### DIFF
--- a/src/main/antlr4/ch/islandsql/grammar/IslandSqlParser.g4
+++ b/src/main/antlr4/ch/islandsql/grammar/IslandSqlParser.g4
@@ -1394,7 +1394,7 @@ createView:
 ;
 
 postgresqlViewOptions:
-    K_WITH options+=postgresqlOption (COMMA options+=postgresqlOption)*
+    K_WITH LPAR options+=postgresqlOption (COMMA options+=postgresqlOption)* RPAR
 ;
 
 // used also for materialized view and therefore name is a qualifiedName


### PR DESCRIPTION
closes #155 