### PR TITLE
support for Java-style single-line comments in the scope lexer

### DIFF
--- a/src/main/antlr4/ch/islandsql/grammar/IslandSqlScopeLexer.g4
+++ b/src/main/antlr4/ch/islandsql/grammar/IslandSqlScopeLexer.g4
@@ -103,7 +103,7 @@ QUOTED_ID: '"' .*? '"' ('"' .*? '"')* -> channel(HIDDEN);
 
 ML_COMMENT: '/*' {getDialect() != IslandSqlDialect.ORACLEDB}? IN_AND_NESTED_COMMENT '*/' -> channel(HIDDEN);
 ML_COMMENT_ORCL: '/*' {getDialect() == IslandSqlDialect.ORACLEDB}? .*? '*/' -> type(ML_COMMENT), channel(HIDDEN);
-SL_COMMENT: '--' ~[\r\n]* -> channel(HIDDEN);
+SL_COMMENT: ('--'|'//') ~[\r\n]* -> channel(HIDDEN);
 
 /*----------------------------------------------------------------------------*/
 // SQL*Plus commands (as single tokens, similar to comments)


### PR DESCRIPTION
fixes #190