### PR TITLE
quick fix for #250

### DIFF
--- a/src/main/antlr4/ch/islandsql/grammar/IslandSqlScopeLexer.g4
+++ b/src/main/antlr4/ch/islandsql/grammar/IslandSqlScopeLexer.g4
@@ -549,7 +549,7 @@ WC_ANY_OTHER: . -> more;
 mode PACKAGE_MODE;
 
 // fail-safe, process tokens that are waiting to be assigned after "more"
-PKG_EOF: EOF -> popMode;
+PKG_EOF: EOF -> popMode, channel(HIDDEN);
 
 PKG_STMT: 'end' (COMMENT_OR_WS+ NAME)? COMMENT_OR_WS* ';' -> popMode;
 


### PR DESCRIPTION
We assume at this moment that everything that was not scoped properly is out of scope. This is okay for the case shown in the issue. However, I consider it only a temporary fix.

closes #250

